### PR TITLE
fix: TypeError: "cwd" must be a string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ Diable.daemonize = (script, args, opts) => {
     let stdout = opts.stdout || "ignore"
       , stderr = opts.stderr || "ignore"
       , env = opts.env || process.env
-      , cwd = opts.cwd || process.cwd
+      , cwd = opts.cwd || process.cwd()
       ;
 
 


### PR DESCRIPTION
In Node 8, using process.cwd as a property rather than a method throws.